### PR TITLE
Fix copy via stdin over SSH.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drewsilcock/limeade
 
-go 1.23
+go 1.24.0
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
## Meta

Hi there! Thanks for forking `lemonade`, it needed some love and I'm happy to see the steps you've taken with `limeade`. I'm attempting to use `devpod` to develop from a thin client (i.e., an old MacBook), and I noticed an issue with neovim when using `limeade`.

I've fixed this here. There are some other issues I'd be interested in opening, or just discussions worth having, if you're looking for collaboration on this repo. For instance:

1. macOS uses `/var/folders...` instead of `/tmp` when running `limeade server`

Despite the code seeming like it should do otherwise (`server` appears hard-coded to `/tmp` except on windows), somehow we're getting the "macOS equivalent" of `/tmp` when running `server`. This is probably actually idiomatic behavior on macOS which should be kept, but
- It'd be nice to understand if that `GOOS.windows` check is somehow including macOS
- We could update the README to point this out (took me a second to figure out, nbd)

2. Neovim excepts `limeade open` to be available

Not really an issue with _limeade_, but my guess is there's a big crossover between the user base of `neovim` and `lemonade`. `lemonade` is effectively dead (and imo should be removed from neovim), but [neovim does except `open`](https://github.com/search?q=repo%3Aneovim%2Fneovim%20lemonade&type=code) as an option on `lemonade`.

Again, I think this can be solved by updating the README to point out this out re:neovim.

Anyways - what I'm really saying is I like what you've done and I'd like to contribute, because it would be awfully nice to get this app shipshape and then get neovim to point to this rather than abandonware. Thanks for your efforts!

## PR Content

Fixes copy via stdin over SSH.

Repro:

1. Start limeade server
2. SSH and forward limeade

```
$ ssh -R /tmp/limeade.sock:/tmp/limeade.sock user@host
```

3. Pass limeade data via stdin

```
$ echo 'foo' | limeade copy
```

Expected:

```
$ 10:20AM INF Copied 9 bytes to clipboard
```

Actual:

```
10:20AM INF Copied 0 bytes to clipboard
```
